### PR TITLE
test: fix grep invocation on test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ compile-macos:
 # fails is grep does find a failed test case
 # https://stackoverflow.com/questions/15367674/bash-one-liner-to-exit-with-the-opposite-status-of-a-grep-command/21788642
 test:
-	sqlite3 < test/$(suite).sql | (! grep -E "\d+.0")
+	! sqlite3 < test/$(suite).sql | grep -Px "\d+.0"


### PR DESCRIPTION
Use of `\d+` requires use of PCREs. Extended regular expressions
include `+`, but not `\d`.

Also, normalize a bit the negation of grep result: on a pipeline, the
exit status is the one of the last command. You can negate it by
putting `!` in front of the pipeline.