### PR TITLE
build: shorten a bit the makefile using pattern rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
             - name: Download SQLite sources
               shell: bash
               run: |
-                  make prepare-dist
                   make download-sqlite
                   make download-native
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,6 @@ jobs:
             - name: Download SQLite sources
               shell: bash
               run: |
-                  make prepare-dist
                   make download-sqlite
                   make download-native
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-.PHONY: prepare-dist download-sqlite download-native compile-linux compile-windows compile-macos test
+.PHONY: download-sqlite download-native compile-linux compile-windows compile-macos test clean
 
-prepare-dist:
-	mkdir -p dist
-	rm -f dist/*
+clean:
+	rm -rf dist
 
 download-sqlite:
 	curl -L http://sqlite.org/$(SQLITE_RELEASE_YEAR)/sqlite-amalgamation-$(SQLITE_VERSION).zip --output src.zip
@@ -12,37 +11,22 @@ download-sqlite:
 download-native:
 	curl -L https://github.com/sqlite/sqlite/raw/master/ext/misc/json1.c --output src/sqlite3-json1.c
 
-compile-linux:
-	gcc -fPIC -shared src/sqlite3-crypto.c src/crypto/*.c -o dist/crypto.so -lm
-	gcc -fPIC -shared src/sqlite3-json1.c -o dist/json1.so -lm
-	gcc -fPIC -shared src/sqlite3-math.c -o dist/math.so -lm
-	gcc -fPIC -shared src/sqlite3-re.c src/re.c -o dist/re.so -lm
-	gcc -fPIC -shared src/sqlite3-stats.c -o dist/stats.so -lm
-	gcc -fPIC -shared src/sqlite3-text.c -o dist/text.so -lm
-	gcc -fPIC -shared src/sqlite3-unicode.c -o dist/unicode.so -lm
-	gcc -fPIC -shared src/sqlite3-vsv.c -o dist/vsv.so -lm
+dist:
+	@mkdir -p dist
+dist/crypto.so dist/crypto.dll dist/crypto.dylib: $(wildcard src/crypto/*.c)
+dist/%.so: src/sqlite3-%.c
+	gcc -fPIC -shared $^ -o $@ -lm
+dist/%.dll: src/sqlite3-%.c
+	gcc -shared -I. $^ -o $@
+dist/%.dylib: src/sqlite3-%.c
+	gcc -fPIC -dynamiclib -I src $^ -o $@ -lm
 
-compile-windows:
-	gcc -shared -I. src/sqlite3-crypto.c src/crypto/*.c -o dist/crypto.dll -lm
-	gcc -shared -I. src/sqlite3-json1.c -o dist/json1.dll
-	gcc -shared -I. src/sqlite3-math.c -o dist/math.dll
-	gcc -shared -I. src/sqlite3-re.c src/re.c -o dist/re.dll
-	gcc -shared -I. src/sqlite3-stats.c -o dist/stats.dll
-	gcc -shared -I. src/sqlite3-text.c -o dist/text.dll
-	gcc -shared -I. src/sqlite3-unicode.c -o dist/unicode.dll
-	gcc -shared -I. src/sqlite3-vsv.c -o dist/vsv.dll
-
-compile-macos:
-	gcc -fPIC -dynamiclib -I src src/sqlite3-crypto.c src/crypto/*.c -o dist/crypto.dylib -lm
-	gcc -fPIC -dynamiclib -I src src/sqlite3-json1.c -o dist/json1.dylib -lm
-	gcc -fPIC -dynamiclib -I src src/sqlite3-math.c -o dist/math.dylib -lm
-	gcc -fPIC -dynamiclib -I src src/sqlite3-re.c src/re.c -o dist/re.dylib -lm
-	gcc -fPIC -dynamiclib -I src src/sqlite3-stats.c -o dist/stats.dylib -lm
-	gcc -fPIC -dynamiclib -I src src/sqlite3-text.c -o dist/text.dylib -lm
-	gcc -fPIC -dynamiclib -I src src/sqlite3-unicode.c -o dist/unicode.dylib -lm
-	gcc -fPIC -dynamiclib -I src src/sqlite3-vsv.c -o dist/vsv.dylib -lm
+extensions = crypto json1 math re stats text unicode vsv
+compile-linux: dist $(extensions:%=dist/%.so)
+compile-windows: dist $(extensions:%=dist/%.dll)
+compile-macos: dist $(extensions:%=dist/%.dylib)
 
 # fails is grep does find a failed test case
 # https://stackoverflow.com/questions/15367674/bash-one-liner-to-exit-with-the-opposite-status-of-a-grep-command/21788642
 test:
-	sqlite3 < test/$(suite).sql | (! grep -E "\d+.0")
+	! sqlite3 < test/$(suite).sql | grep -Pvx "\d+.1"


### PR DESCRIPTION
This also fixes the test rule which was incorrect. Use of `\d+`
requires use of PCREs. Extended regular expressions include `+`, but
not `\d`.

Also, normalize a bit the negation of grep result: on a pipeline, the
exit status is the one of the last command. You can negate it by
putting `!` in front of the pipeline.

This is a replacement for #20