### PR TITLE
Fix undefined behavior shift in MD5

### DIFF
--- a/src/crypto/md5.c
+++ b/src/crypto/md5.c
@@ -52,7 +52,7 @@ void md5_transform(MD5_CTX* ctx, const BYTE data[]) {
     // endian byte order CPU. Reverse all the bytes upon input, and re-reverse them
     // on output (in md5_final()).
     for (i = 0, j = 0; i < 16; ++i, j += 4)
-        m[i] = (data[j]) + (data[j + 1] << 8) + (data[j + 2] << 16) + (data[j + 3] << 24);
+        m[i] = (data[j]) + (data[j + 1] << 8) + (data[j + 2] << 16) + ((WORD)data[j + 3] << 24);
 
     a = ctx->state[0];
     b = ctx->state[1];


### PR DESCRIPTION
The "unsigned char" read from "data" is promoted to "int" and the left shift by 24 sometimes results in signed overflow. UBSan reveals this error when running the tests.

I also reported this issue upstream, but it looks abandoned and is likely to ever see a fix: https://github.com/B-Con/crypto-algorithms/issues/33