### PR TITLE
Do not allow zero-length VLAs in soundex library

### DIFF
--- a/src/fuzzy/refined_soundex.c
+++ b/src/fuzzy/refined_soundex.c
@@ -76,7 +76,7 @@ char* refined_soundex(const char* str) {
     char code[str_len + 1];
 
     // temporary buffer to encode string
-    char buf[str_len];
+    char buf[str_len+1];
 
     // set first value to first char in str
     code[0] = toupper(str[0]);

--- a/src/fuzzy/soundex.c
+++ b/src/fuzzy/soundex.c
@@ -70,7 +70,7 @@ char* soundex(const char* str) {
     char* code = malloc(5 * sizeof(char));
 
     // temporary buffer to encode string
-    char buf[str_len];
+    char buf[str_len+1];
 
     // set first value to first char in str
     code[0] = toupper(str[0]);


### PR DESCRIPTION
When the string is empty, the program creates a zero-length VLA which is undefined behavior. Instead, always allocate an extra byte as though accounting for the null terminator in the original string. This error is caught by UBSan while running the tests.

I did not take time to report this upstream (to @Rostepher) because it looks to be abandoned.