### PR TITLE
Fix buffer overflow in soundex library

### DIFF
--- a/src/fuzzy/refined_soundex.c
+++ b/src/fuzzy/refined_soundex.c
@@ -106,7 +106,7 @@ char* refined_soundex(const char* str) {
 
     // allocate space for final code
     // d will be length of the code + 1
-    char* result = malloc(d * sizeof(char));
+    char* result = malloc((d + 1) * sizeof(char));
 
     // copy final code into result and null terminate
     for (unsigned i = 0; i < d; i++) {


### PR DESCRIPTION
No space was allocated for the null terminator in the result buffer. ASan catches this error when running the tests.

There's a potential issue that `d` (and `i`) will overflow, computing an incorrect result, except that they're tied to a VLA and the program would crash via stack overflow well before that point. Especially considering the VLAs (#58), this soundex library is questionable and probably shouldn't be used on untrusted input without careful review and fixes, and VLA removal.