### PR TITLE
Adding FreeBSD compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ compile-linux:
 	gcc -fPIC -shared src/sqlite3-fileio.c -o dist/fileio.so
 	gcc -fPIC -shared src/sqlite3-fuzzy.c src/fuzzy/*.c -o dist/fuzzy.so
 	gcc -fPIC -shared src/sqlite3-ipaddr.c -o dist/ipaddr.so
+	gcc -fPIC -shared src/sqlite3-json1.c -o dist/json1.so
 	gcc -fPIC -shared src/sqlite3-math.c -o dist/math.so -lm
 	gcc -fPIC -shared src/sqlite3-re.c src/re.c -o dist/re.so
 	gcc -fPIC -shared src/sqlite3-stats.c -o dist/stats.so -lm

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ compile-linux:
 	gcc -fPIC -shared src/sqlite3-fileio.c -o dist/fileio.so
 	gcc -fPIC -shared src/sqlite3-fuzzy.c src/fuzzy/*.c -o dist/fuzzy.so
 	gcc -fPIC -shared src/sqlite3-ipaddr.c -o dist/ipaddr.so
-	gcc -fPIC -shared src/sqlite3-json1.c -o dist/json1.so
 	gcc -fPIC -shared src/sqlite3-math.c -o dist/math.so -lm
 	gcc -fPIC -shared src/sqlite3-re.c src/re.c -o dist/re.so
 	gcc -fPIC -shared src/sqlite3-stats.c -o dist/stats.so -lm

--- a/src/sqlite3-ipaddr.c
+++ b/src/sqlite3-ipaddr.c
@@ -13,6 +13,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __FreeBSD__
+#include <netinet/in.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#endif
+
 #include "sqlite3ext.h"
 
 SQLITE_EXTENSION_INIT1


### PR DESCRIPTION
This pull requests removes a missing source file from the Makefile and adds FreeBSD compatibility. On FreeBSD, `make compile-linux` works as well.