### PR TITLE
build: pre-compiled binaries for windows-x86

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,10 +41,19 @@ jobs:
                   make compile-linux-arm64
                   make pack-linux
 
+            - name: Install MSYS2 and 'mingw-w64-i686-toolchain'
+              if: matrix.os == 'windows-latest'
+              uses: msys2/setup-msys2@v2
+              with:
+                  cache: true
+                  install: mingw-w64-i686-toolchain
+                  update: true
+
             - name: Build for Windows
               if: matrix.os == 'windows-latest'
               shell: bash
               run: |
+                  $RUNNER_TEMP/msys64/msys2_shell.cmd -defterm -no-start -mingw32 -lc "mingw32-make compile-windows-x86"
                   make compile-windows
                   make pack-windows
 

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,23 @@ compile-windows:
 	gcc -O3 $(WINDO_FLAGS) src/sqlite3-vsv.c src/vsv/*.c -o dist/vsv.dll -lm
 	gcc -O1 $(WINDO_FLAGS) -include src/regexp/constants.h src/sqlite3-sqlean.c src/crypto/*.c src/define/*.c src/fileio/*.c src/fuzzy/*.c src/math/*.c src/regexp/*.c src/regexp/pcre2/*.c src/stats/*.c src/text/*.c src/unicode/*.c src/uuid/*.c src/vsv/*.c -o dist/sqlean.dll -lm
 
+compile-windows-x86:
+	mkdir -p dist/x86
+	gcc -O1 $(WINDO_FLAGS) src/sqlite3-crypto.c src/crypto/*.c -o dist/x86/crypto.dll
+	gcc -O3 $(WINDO_FLAGS) src/sqlite3-define.c src/define/*.c -o dist/x86/define.dll
+	gcc -O3 $(WINDO_FLAGS) src/sqlite3-fileio.c src/fileio/*.c -o dist/x86/fileio.dll
+	gcc -O1 $(WINDO_FLAGS) src/sqlite3-fuzzy.c src/fuzzy/*.c -o dist/x86/fuzzy.dll
+	gcc -O3 $(WINDO_FLAGS) src/sqlite3-math.c src/math/*.c -o dist/x86/math.dll -lm
+	gcc -O3 $(WINDO_FLAGS) src/sqlite3-regexp.c -include src/regexp/constants.h src/regexp/*.c src/regexp/pcre2/*.c -o dist/x86/regexp.dll
+	gcc -O3 $(WINDO_FLAGS) src/sqlite3-stats.c src/stats/*.c -o dist/x86/stats.dll -lm
+	gcc -O3 $(WINDO_FLAGS) src/sqlite3-text.c src/text/*.c -o dist/x86/text.dll
+	gcc -O3 $(WINDO_FLAGS) src/sqlite3-unicode.c src/unicode/*.c -o dist/x86/unicode.dll
+	gcc -O3 $(WINDO_FLAGS) src/sqlite3-uuid.c src/uuid/*.c -o dist/x86/uuid.dll
+	gcc -O3 $(WINDO_FLAGS) src/sqlite3-vsv.c src/vsv/*.c -o dist/x86/vsv.dll -lm
+	gcc -O1 $(WINDO_FLAGS) -include src/regexp/constants.h src/sqlite3-sqlean.c src/crypto/*.c src/define/*.c src/fileio/*.c src/fuzzy/*.c src/math/*.c src/regexp/*.c src/regexp/pcre2/*.c src/stats/*.c src/text/*.c src/unicode/*.c src/uuid/*.c src/vsv/*.c -o dist/x86/sqlean.dll -lm
+
 pack-windows:
+	7z a -tzip dist/sqlean-win-x86.zip ./dist/x86/*.dll
 	7z a -tzip dist/sqlean-win-x64.zip ./dist/*.dll
 
 compile-macos:


### PR DESCRIPTION
This patch changes to add pre-compiled binaries for x86 Windows.
This PR is related to issue #117 .

## Changes
- Install MSYS2 and 'mingw-w64-i686-toolchain' on Windows runner
> Install this because the GitHub-hosted runner's 'windows-2022' image does not include a built-in x86 toolchain.
- Add the code to build the binaries for x86 with MSYS2 and the toolchain installed above, and archive them.

## Results of execute the `file` command on the build output
<img width="842" alt="Screenshot 2024-06-02 at 00 05 05" src="https://github.com/nalgeon/sqlean/assets/64626662/20e87df0-b12a-46de-ab4f-e925336f8feb">

Any comments, reviews, etc. are welcome.
Thank you. :)