### PR TITLE
escape quotes in undefine impl

### DIFF
--- a/src/define/manage.c
+++ b/src/define/manage.c
@@ -273,8 +273,8 @@ static void define_free(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
  */
 static void define_undefine(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
     char* template =
-        "delete from sqlean_define where name = '%s';"
-        "drop table if exists \"%s\";";
+        "delete from sqlean_define where name = '%q';"
+        "drop table if exists \"%w\";";
     const char* name = (const char*)sqlite3_value_text(argv[0]);
     char* sql = sqlite3_mprintf(template, name, name);
     if (!sql) {

--- a/test/define.sql
+++ b/test/define.sql
@@ -57,21 +57,28 @@ select '53', count(*) = 0 from sqlean_define where name = 'strcut';
 select '54', count(*) = 0 from sqlite_master where type = 'table' and name = 'strcut';
 select '55', count(*) = 5 from sqlean_define;
 
+create table innocent (i);
+select define('f ''; drop table innocent; --', '1');
+select undefine('f ''; drop table innocent; --');
+select define('f "; drop table innocent; --', '1');
+select undefine('f "; drop table innocent; --');
+select '61', count(*) = 1 from sqlite_master where type = 'table' and name = 'innocent';
+
 select define_free();
 
-select '61', eval('select 42') = '42';
-select '62', eval('select 1, 2, 3') = '1 2 3';
-select '63', eval('select 1, 2, 3', ', ') = '1, 2, 3';
-select '64', eval('select abs(-42)') = '42';
-select '65', eval('select 10 + 32') = '42';
-select '66', eval('select ''hello''') = 'hello';
-select '67', eval('select null') = '';
-select '68', eval('select 1; select 2; select 3;') = '1 2 3';
+select '71', eval('select 42') = '42';
+select '72', eval('select 1, 2, 3') = '1 2 3';
+select '73', eval('select 1, 2, 3', ', ') = '1, 2, 3';
+select '74', eval('select abs(-42)') = '42';
+select '75', eval('select 10 + 32') = '42';
+select '76', eval('select ''hello''') = 'hello';
+select '77', eval('select null') = '';
+select '78', eval('select 1; select 2; select 3;') = '1 2 3';
 
-select '71', eval('create table tmp(value int)') is null;
-select '72', count(*) = 1 from sqlite_master where type = 'table' and name = 'tmp';
-select '73', eval('insert into tmp(value) values (1), (2), (3)') is null;
-select '74', count(*) = 3 from tmp;
-select '75', eval('select value from tmp') = '1 2 3';
-select '76', eval('drop table tmp') is null;
-select '77', count(*) = 0 from sqlite_master where type = 'table' and name = 'tmp';
+select '81', eval('create table tmp(value int)') is null;
+select '82', count(*) = 1 from sqlite_master where type = 'table' and name = 'tmp';
+select '83', eval('insert into tmp(value) values (1), (2), (3)') is null;
+select '84', count(*) = 3 from tmp;
+select '85', eval('select value from tmp') = '1 2 3';
+select '86', eval('drop table tmp') is null;
+select '87', count(*) = 0 from sqlite_master where type = 'table' and name = 'tmp';


### PR DESCRIPTION
## Context

`undefine` do not escape function name parameter (just use plain `%s` format specifier) which can lead to SQL injection if non-trusted user can create custom functions like this: `select define('f ''; drop table innocent; --', '1');`

`sqlean` must use dedicated `%q` and `%w` [specifiers](https://www.sqlite.org/printf.html#percentq) which automatically duplicate single(')/double quote(") in order to avoid such issues.