### PR TITLE
Fixing potential crash in readline function caused by neglecting resu…

### DIFF
--- a/src/fileio/scan.c
+++ b/src/fileio/scan.c
@@ -60,12 +60,15 @@ static ssize_t readline(char** lineptr, size_t* n, FILE* stream) {
     }
     p = bufptr;
     while (c != EOF) {
-        if ((ssize_t)(p - bufptr) > (ssize_t)(size - 1)) {
-            size = size + 128;
-            bufptr = realloc(bufptr, size);
-            if (bufptr == NULL) {
+        if ((ssize_t)(p - bufptr)+1 > (ssize_t)(size)) {
+            size_t offset = p - bufptr; // save offset
+	    size = size + 128;
+	    char * new_buf = realloc(bufptr, size);
+            if (new_buf == NULL) {
                 return -1;
             }
+	    bufptr = new_buf;
+	    p = bufptr + offset; // recalculate p using the saved offset
         }
         *p++ = c;
         if (c == '\n') {


### PR DESCRIPTION
Fixing potential crash in readline function caused by neglecting result of realloc.
sqlite3 crashed if using "select rowid, value, name from fileio_scan('README.md');"

Problem found and fixed using Claude. Here the explanation:
The issue here is that when realloc is called, it may return a new pointer while freeing the old one. If this happens, p would still be pointing to the old memory block, which has been freed. Continuing to use p after this point could lead to memory corruption.
The correct approach would be to adjust p after realloc to point to the corresponding position in the newly allocated memory.